### PR TITLE
added os-release for linux mint edge

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,6 +23,12 @@ case $distro in
     echo "Installing on Debian or derivative"
     dpkg -s zenity xinput &> /dev/null || sudo apt install zenity xinput
     ;;
+  
+  # Entry for Linux Mint 21.3 Edge
+  "ubuntu debian")
+    echo "Installing on Linux Mint Edge"
+    dpkg -s zenity xinput &> /dev/null || sudo apt install zenity xinput
+    ;;  
 
   "fedora")
     echo "Installing on Fedora"


### PR DESCRIPTION
The ID-LIKE name for Linux mint 21.3 edge is not Debian and therefore is unrecognized by the install script even the tool would work so I added an entry to the install.sh file to allow the installation on Linux Mint edge
os-release file
`
NAME="Linux Mint"
VERSION="21.3 (Virginia)"
ID=linuxmint
ID_LIKE="ubuntu debian"
PRETTY_NAME="Linux Mint 21.3"
VERSION_ID="21.3"
HOME_URL="https://www.linuxmint.com/"
SUPPORT_URL="https://forums.linuxmint.com/"
BUG_REPORT_URL="http://linuxmint-troubleshooting-guide.readthedocs.io/en/latest/"
PRIVACY_POLICY_URL="https://www.linuxmint.com/"
VERSION_CODENAME=virginia
UBUNTU_CODENAME=jammy

`